### PR TITLE
Add Ansible Configuration

### DIFF
--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -1,0 +1,39 @@
+# Vault Raft Backup Agent - Ansible Configuration
+
+This directory contains Ansible instructions to deploy the Raft Backup Agent. The tasks of the role `vault-raft-backup-agent` are derived from the [description of the backup approach](../Readme.md).
+
+## Ansible Variables
+
+All variables of the role are documented in the file [`main.yml`](./roles/vault-raft-backup-agent/defaults/main.yml).
+
+The role `vault-raft-backup-agent` assumes that the roleid and secretid are defined. The backup agent and the backup job use these variables to authenticate against the Vault:
+
+* `vault_raft_bck_role_id`: The AppRole roleid
+* `vault_raft_bck_secret_id`: The AppRole secretid
+
+Note that the **secretid is removed by default**. Set the variable `remove_secret_id_file_after_reading: no` to alter this behavior.
+
+## Usage
+
+### Role Usage / Playbook
+An example playbook is provided in the file [`playbook.yml`](./playbook.yml)
+
+```bash
+# run the playbook with a custom inventory (not included in this repo)
+$ ansible-playbook playbook.yml -i inventory
+```
+
+### Check Snapshot Job Status
+
+
+```bash
+
+
+```
+
+
+## Limitations
+The Ansible role comes with the following limitations:
+
+* Does not configure a cron job, only a systemd timer/service pair
+* Exposes a Vault token on the snapshot host (with limited privileges though)

--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -25,12 +25,9 @@ $ ansible-playbook playbook.yml -i inventory
 
 ### Check Snapshot Job Status
 
-
 ```bash
-
-
+$ systemctl list-timers
 ```
-
 
 ## Limitations
 The Ansible role comes with the following limitations:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,5 @@
+---
+
+- hosts: vault
+  roles:
+    - { role: vault-raft-backup-agent, tags: vault-raft-backup-agent }

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -1,0 +1,73 @@
+---
+
+# Vault configuration directory
+vault_snapshot_config_dir: '/etc/vault.d'
+# Name for pid file
+vault_snapshot_pid_file_name: 'vault-raft-backup-agent.pid'
+# Location of pid file
+vault_snapshot_pid_dir: '{{ vault_snapshot_config_dir }}'
+
+# Vault API address
+vault_address: '127.0.0.1'
+# Vault API tls, choosing 'no' here will change the protocol
+# for vault_address from 'http' (default, for dev server) to 'https'
+vault_tls_disable: yes
+
+# Vault snapshot agent config file destination on remote host
+vault_snapshot_agent_config_file: '{{ vault_snapshot_config_dir }}/vault_snapshot_agent.hcl'
+# Vault snapshot agent config file template
+vault_snapshot_agent_config_file_template: 'templates{{ vault_snapshot_config_dir }}/vault_snapshot_agent.hcl.j2'
+
+# Systemd directory for service and timer files on remote host
+vault_snapshot_systemd_dir: '/etc/systemd/system'
+# Systemd service name for snapshot agent
+vault_snapshot_systemd_service_name: 'vault-raft-backup-agent.service'
+
+# Systemd timer name
+vault_snapshot_systemd_timer_name: 'vault-snap-agent.timer'
+# Systemd timer service name; this service performs the actual snapshotting
+vault_snapshot_systemd_timer_service_name: 'vault-snap-agent.service'
+# Systemd timer OnActiveSec, run 1s after activation
+vault_snapshot_systemd_timer_onactivesec: '1s'
+# Systemd timer OnUnitActiveSec, run monotonic timer every hour after activation
+vault_snapshot_systemd_timer_onunitactivesec: '1h'
+# Systemd timer description
+vault_snapshot_systemd_timer_description: 'Vault integrated storage snapshot'
+
+# Owner/Group for configuration directory and files
+vault_user: vault
+vault_group: vault
+
+# Path to vault binary
+vault_bin_path: '/usr/local/bin'
+
+# path to roleid and secretid files for AppRole auth
+vault_snapshot_approle_roleid_file: '{{ vault_snapshot_config_dir }}/snap-roleid'
+vault_snapshot_approle_secretid_file: '{{ vault_snapshot_config_dir }}/snap-secretid'
+
+# This can be set to false to disable the default behavior
+# of removing the secret ID file after it's been read:
+# https://www.vaultproject.io/docs/agent/autoauth/methods/approle#remove_secret_id_file_after_reading
+remove_secret_id_file_after_reading: no
+# The snapshot service will no longer find a valid token if you set this to 'yes'
+# TODO: Consider using an additional listener for the Vault agent with `use_auto_auth_token=true`
+
+# Location of the Vault token, ideally a ramdisk, see also:
+# https://www.vaultproject.io/docs/agent/autoauth/sinks/file
+vault_snapshot_token_location: '/tmp/vault-raft-backup-agent-token'
+# Set to 0000 to prevent Vault from modifying the file mode
+# The file is currently written with 0640 permissions as default
+vault_snapshot_token_mode: '0000'
+
+# Snapshot output directory
+vault_snapshot_dir: '/opt/vault/snapshots'
+# Snapshot file name format
+vault_snapshot_file_name: 'vault-raft_$(date +%F-%H%M).snapshot'
+
+# Snapshot retention find time filter,
+# one of 'mtime' or 'atime', see `man find`
+vault_snapshot_retention_find_mode: 'mtime'
+# Snapshot retention, data was last modified/accessed 7*24 hours ago
+vault_snapshot_retention_time: '+7'
+# Action to take on expired files
+vault_snapshot_retention_find_action: 'rm'

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -66,7 +66,7 @@ vault_snapshot_token_mode: '0000'
 # Snapshot output directory
 vault_snapshot_dir: '/opt/vault/snapshots'
 # Snapshot file name format
-vault_snapshot_file_name: 'vault-raft_$(date +%F-%H%M).snapshot'
+vault_snapshot_file_name: 'vault-raft_$(date +%%F-%%H%%M).snapshot'
 
 # Snapshot retention find time filter,
 # one of 'mtime' or 'atime', see `man find`

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -41,6 +41,12 @@ vault_group: vault
 # Path to vault binary
 vault_bin_path: '/usr/local/bin'
 
+# Variables for actual AppRole roleid and secretid. These variables can be defined
+# manually or generated with the terraform configuration from this repo.
+# Use Ansible Vault to encrypt the secretid.
+vault_raft_bck_role_id: ''
+vault_raft_bck_secret_id: 'sensitive'
+
 # path to roleid and secretid files for AppRole auth
 vault_snapshot_approle_roleid_file: '{{ vault_snapshot_config_dir }}/snap-roleid'
 vault_snapshot_approle_secretid_file: '{{ vault_snapshot_config_dir }}/snap-secretid'

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -58,7 +58,7 @@ remove_secret_id_file_after_reading: yes
 
 # Location of the Vault token, ideally a ramdisk, see also:
 # https://www.vaultproject.io/docs/agent/autoauth/sinks/file
-vault_snapshot_token_location: '/tmp/vault-raft-backup-agent-token'
+vault_snapshot_token_location: '/run/vault-snap-agent/token'
 # Set to 0000 to prevent Vault from modifying the file mode
 # The file is currently written with 0640 permissions as default
 vault_snapshot_token_mode: '0000'

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -54,9 +54,7 @@ vault_snapshot_approle_secretid_file: '{{ vault_snapshot_config_dir }}/snap-secr
 # This can be set to false to disable the default behavior
 # of removing the secret ID file after it's been read:
 # https://www.vaultproject.io/docs/agent/autoauth/methods/approle#remove_secret_id_file_after_reading
-remove_secret_id_file_after_reading: no
-# The snapshot service will no longer find a valid token if you set this to 'yes'
-# TODO: Consider using an additional listener for the Vault agent with `use_auto_auth_token=true`
+remove_secret_id_file_after_reading: yes
 
 # Location of the Vault token, ideally a ramdisk, see also:
 # https://www.vaultproject.io/docs/agent/autoauth/sinks/file

--- a/ansible/roles/vault-raft-backup-agent/handlers/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: daemon reload
+  service:
+    daemon_reload: yes

--- a/ansible/roles/vault-raft-backup-agent/tasks/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/tasks/main.yml
@@ -9,7 +9,7 @@
     group: '{{ vault_group }}'
 
 - name: write secretid
-  # no_log: yes
+  no_log: yes
   copy:
     dest: '{{ vault_snapshot_approle_secretid_file }}'
     content: '{{ vault_raft_bck_secret_id }}'

--- a/ansible/roles/vault-raft-backup-agent/tasks/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+
+- name: write roleid
+  copy:
+    dest: '{{ vault_snapshot_approle_roleid_file }}'
+    content: '{{ vault_raft_bck_role_id }}'
+    mode: '0640'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+
+- name: write secretid
+  # no_log: yes
+  copy:
+    dest: '{{ vault_snapshot_approle_secretid_file }}'
+    content: '{{ vault_raft_bck_secret_id }}'
+    mode: '0640'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+
+- name: write snapshot agent configuration file
+  template:
+    src: '{{ vault_snapshot_agent_config_file_template }}'
+    dest: '{{ vault_snapshot_agent_config_file }}'
+    mode: '0640'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+
+# Vault backup agent systemd config
+- name: create systemd service file for backup agent
+  template:
+    src: 'templates{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_service_name }}.j2'
+    dest: '{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_service_name }}'
+  notify:
+    - daemon reload
+
+- name: start and enable systemd service
+  service:
+    name: '{{ vault_snapshot_systemd_service_name }}'
+    enabled: yes
+    state: started
+
+# Timer systemd config
+- name: create systemd timer service file for snapshot service
+  template:
+    src: 'templates{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_timer_service_name }}.j2'
+    dest: '{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_timer_service_name }}'
+  notify:
+    - daemon reload
+
+- name: create systemd timer file for snapshot service
+  template:
+    src: 'templates{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_timer_name }}.j2'
+    dest: '{{ vault_snapshot_systemd_dir }}/{{ vault_snapshot_systemd_timer_name }}'
+  notify:
+    - daemon reload
+
+- name: ensure snapshot directory exists
+  file:
+    path: '{{ vault_snapshot_dir }}'
+    state: directory
+    mode: '0755'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+
+- name: start systemd timer
+  service:
+    name: '{{ vault_snapshot_systemd_timer_name }}'
+    state: started

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
@@ -1,15 +1,17 @@
 [Unit]
-Description=Vault Agent
+Description=Vault Snapshot Agent
 Requires=network-online.target
 After=network-online.target
 
 [Service]
 Restart=on-failure
-ExecStart={{ vault_bin_path }}/vault agent -config {{ vault_snapshot_agent_config_file }}
+ExecStart={{ vault_bin_path }}/vault agent -config={{ vault_snapshot_agent_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
-KillSignal=SIGTERM
+KillSignal=SIGINT
 User={{ vault_user }}
 Group={{ vault_group }}
+RuntimeDirectoryMode=0750
+RuntimeDirectory=vault-snap-agent
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Vault Agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+ExecStart={{ vault_bin_path }}/vault agent -config {{ vault_snapshot_agent_config_file }}
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+User={{ vault_user }}
+Group={{ vault_group }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ vault_snapshot_systemd_timer_description }}
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c ' \
+  VAULT_TOKEN=$(cat {{ vault_snapshot_token_location }}) \
+  VAULT_ADDR="{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200" \
+  {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}" \
+'
+ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -4,7 +4,7 @@ Description={{ vault_snapshot_systemd_timer_description }}
 [Service]
 Type=oneshot
 Environment=VAULT_ADDR={{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200
-ExecStart=/bin/sh -c 'VAULT_TOKEN="$$(cat /tmp/vault-raft-backup-agent-token)" {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
+ExecStart=/bin/sh -c 'VAULT_TOKEN="$$(cat /run/vault-snap-agent/token)" {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 
 [Install]

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,7 +3,7 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-Environment=VAULT_ADDR="{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200"
+Environment=VAULT_ADDR={{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200
 ExecStart=/bin/sh -c 'VAULT_TOKEN="$$(cat /tmp/vault-raft-backup-agent-token)" {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,11 +3,9 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c ' \
-  VAULT_TOKEN=$(cat {{ vault_snapshot_token_location }}) \
-  VAULT_ADDR="{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200" \
-  {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}" \
-'
+Environment=VAULT_TOKEN=$(cat {{ vault_snapshot_token_location }})
+Environment=VAULT_ADDR="{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200"
+ExecStart={{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 
 [Install]

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,9 +3,8 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-Environment=VAULT_TOKEN=$(cat {{ vault_snapshot_token_location }})
 Environment=VAULT_ADDR="{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200"
-ExecStart={{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"
+ExecStart=/bin/sh -c 'VAULT_TOKEN="$$(cat /tmp/vault-raft-backup-agent-token)" {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 
 [Install]

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.timer.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description={{ vault_snapshot_systemd_timer_description }}
+
+[Timer]
+Unit={{ vault_snapshot_systemd_timer_service_name }}
+
+OnActiveSec={{ vault_snapshot_systemd_timer_onactivesec }}
+OnUnitActiveSec={{ vault_snapshot_systemd_timer_onunitactivesec }}
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
@@ -1,0 +1,34 @@
+# Vault agent configuration for Raft snapshots
+
+pid_file = "{{ vault_snapshot_pid_dir }}/{{ vault_snapshot_pid_file_name }}"
+
+vault {
+  address = "{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200"
+}
+
+auto_auth {
+  method {
+    # Authenticate with AppRole
+    # https://www.vaultproject.io/docs/agent/autoauth/methods/approle
+    type      = "approle"
+
+    config = {
+      role_id_file_path = "{{ vault_snapshot_approle_roleid_file }}"
+      secret_id_file_path = "{{ vault_snapshot_approle_secretid_file }}"
+      remove_secret_id_file_after_reading = {{ remove_secret_id_file_after_reading | bool | lower }}
+    }
+  }
+
+  sink {
+    # write Vault token to file
+    # https://www.vaultproject.io/docs/agent/autoauth/sinks/file
+    type = "file"
+
+    config = {
+      # best practice to write the file to a ramdisk (0640)
+      # have a look at wrapped token for advanced configuration
+      path = "{{ vault_snapshot_token_location }}"
+      mode = {{ vault_snapshot_token_mode }}
+    }
+  }
+}


### PR DESCRIPTION
This request adds an Ansible role with examples on how to configure the backup agent with a systemd service/timer pair.

It can be used together with the [Terraform configuration](https://github.com/adfinis-sygroup/vault-raft-backup-agent/pull/1) to automate the deployment of the backup agent.