### PR TITLE
Run s3cmd after vault-snapshot

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -169,7 +169,7 @@ s3cmd mb s3://raft-snapshots
 
 Add s3cmd sync to `vault-snapshot`:
 ```bash
-echo "5 * * * * root /usr/bin/s3cmd sync /opt/vault/snapshots/* s3://raft-snapshots" >> /usr/local/bin/vault-snapshot
+echo "/usr/bin/s3cmd sync /opt/vault/snapshots/* s3://raft-snapshots" >> /usr/local/bin/vault-snapshot
 ```
 
 ## Retention


### PR DESCRIPTION
@pree Is it intended to have "cron like" syntax in the `vault-snapshot` shell script? Shouldn't the sync either:

* be run at the end of the script
* or be added to the crontab?

The PR assumes that the sync should be run as an additional cron entry (because of the 5min after the full hour syntax). However, to achieve the same without additional crontab entry, we should amend the script:

```bash
echo "/usr/bin/s3cmd sync /opt/vault/snapshots/* s3://raft-snapshots" >> /usr/local/bin/vault-snapshot
``` 

What do you think?