### PR TITLE
Improve Docs and Ensure Vault Config Dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The problem: [Snapshot automation](https://learn.hashicorp.com/vault/operations/
 
 A suggested solution: The Vault Agent and the snapshot cronjob can be deployed on a remote backup server or on the Vault instances itself.
 
+## Prerequisites
+
+The automation code (Ansible playbook and Terraform) does not automatically [install the Vault binary](https://learn.hashicorp.com/tutorials/vault/getting-started-install).
+
 ## Vault Policy
 
 Policy for the snapshot agent:

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ A suggested solution: The Vault Agent and the snapshot cronjob can be deployed o
 
 ## Vault Policy
 
-Policy for the snapshot agent (todo TF config):
+Policy for the snapshot agent:
 ```bash
 echo '
 path "sys/storage/raft/snapshot" {
    capabilities = ["read"]
 }' | vault policy write snapshot -
 ```
+
+This policy is included in the [./terraform](./terraform) code.
+
 ## AppRole Authentication
 
-Enable AppRole and create the `vault-snap-agent` role (todo TF config):
+This manual steps for AppRole authentication are automated in the [./terraform](./terraform) code.
+
+Enable AppRole and create the `vault-snap-agent` role:
 ```bash
 vault auth enable approle
 vault write auth/approle/role/vault-snap-agent token_ttl=2h token_policies=snapshot
@@ -24,7 +29,7 @@ vault read auth/approle/role/vault-snap-agent/role-id -format=json | jq -r .data
 vault write -f auth/approle/role/vault-snap-agent/secret-id -format=json | jq -r .data.secret_id # sudo tee vault-host:/etc/vault.d/snap-secretid
 ```
 
-On all Vault servers (todo automate, this is still manual as of today):
+On all Vault servers:
 ```bash
 echo "7581f63b-e36b-e105-0c6d-07c534c916c4" > /etc/vault.d/snap-roleid
 echo "91919667-7587-4a69-a4f9-766358b082ac" > /etc/vault.d/snap-secretid
@@ -36,7 +41,7 @@ chown vault:vault /etc/vault.d/snap-{roleid,secretid}
 
 Configure the vault agent for the snapshots:
 ```bash
-cat << EOF > /etc/vault.d/vault_snapshot_agent.hcl 
+cat << EOF > /etc/vault.d/vault_snapshot_agent.hcl
 # Vault agent configuration for Raft snapshots
 
 vault {
@@ -160,7 +165,7 @@ wget <s3cmd-release-url>
 tar xvf s3cmd-x.x.x.tar.gz
 cd s3cmd-x.x.x
 python setup.py install
-``` 
+```
 
 Configure s3cmd:
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This policy is included in the [./terraform](./terraform) code.
 
 ## AppRole Authentication
 
-This manual steps for AppRole authentication are automated in the [./terraform](./terraform) code.
+These manual steps for AppRole authentication are automated in the [./terraform](./terraform) code.
 
 Enable AppRole and create the `vault-snap-agent` role:
 ```bash

--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -34,3 +34,4 @@ The Ansible role comes with the following limitations:
 
 * Does not configure a cron job, only a systemd timer/service pair
 * Exposes a Vault token on the snapshot host (with limited privileges though)
+* Does not automatically [install the Vault binary](https://learn.hashicorp.com/tutorials/vault/getting-started-install)

--- a/ansible/roles/vault-raft-backup-agent/tasks/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/tasks/main.yml
@@ -5,6 +5,8 @@
     path: '{{ vault_snapshot_config_dir }}'
     state: directory
     mode: '0700'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
 
 - name: write roleid
   copy:

--- a/ansible/roles/vault-raft-backup-agent/tasks/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: ensure Vault snapshot config dir
+  file:
+    path: '{{ vault_snapshot_config_dir }}'
+    state: directory
+    mode: '0700'
+
 - name: write roleid
   copy:
     dest: '{{ vault_snapshot_approle_roleid_file }}'

--- a/terraform/Readme.md
+++ b/terraform/Readme.md
@@ -14,7 +14,7 @@ The Terraform configuration assumes that the following Ansible var files should 
 
 | Description | Terraform Variable forming the Ansible Path | Variable Default Value |
 | --- | --- | --- |
-| The path of the roleid Ansible variable | `${ansible_play_dir}/vars/${ansible_vars_file_role_id}` | `../ansible/raft-backup-roleid.yml` | 
+| The path of the roleid Ansible variable | `${ansible_play_dir}/vars/${ansible_vars_file_role_id}` | `../ansible/raft-backup-roleid.yml` |
 | The path of the secretid Ansible variable |`${ansible_play_dir}/vars/${ansible_vars_file_secret_id}` | `../ansible/raft-backup-secretid.yml` |
 | The location of the password file for Ansible Vault | `ansible_vault_id` | `../ansible/vault-pass` |
 
@@ -26,8 +26,8 @@ Notes:
 ## Usage
 
 ```bash
-# copy and adapt the variables
-$ cp terraform.tfvars{.example,}
+# review the variables
+$ cat terraform.tfvars
 
 # configure access credentials, see also
 # https://www.terraform.io/docs/providers/vault/index.html


### PR DESCRIPTION
This PR elaborates the prerequisites in the README files, especially, that the code will not install Vault binary itself. This is a prerequisite.

Done:
* Links to the Terraform code are made where appropriate.
* Task added to Ansible playbook to ensure the Vault config directory exists

